### PR TITLE
docs: add README with build instructions + MIT LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2025 Dylan Jones
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# dungeaonHack
+# dungeonHack
+
+A simple Moria-like dungeon crawler written in C with SDL2.
+
+## Building
+
+### Linux
+
+```sh
+make
+```
+
+### Windows
+
+```sh
+make -f Makefile.win
+```
+
+## Controls
+
+- Arrow keys: Move
+- `r`: Wait/rest a turn
+- Move onto `>`: Descend stairs
+- `ESC`: Quit the game
+
+## Roadmap
+
+- Expand monster variety and AI
+- Add more dungeon levels and items
+- Implement save/load functionality
+


### PR DESCRIPTION
## Summary
- Add project README with build steps, basic controls and roadmap
- Include MIT LICENSE for 2025

## Testing
- `make`
- `make -f Makefile.win` *(fails: x86_64-w64-mingw32-gcc missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a09bcab3e88326bff98f824f421024